### PR TITLE
Fix gazelle tests

### DIFF
--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "config_test.go",
         "generate_test.go",
     ],
+    data = ["//testdata:all"],
     embed = [":cmake_lib"],
     deps = [
         "@rules_go//go/tools/bazel",

--- a/testdata/BUILD.bazel
+++ b/testdata/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "all",
+    srcs = glob(["**"], exclude=["**/BUILD.bazel"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
## Summary
- include testdata in gazelle tests so runfiles contain CMake files
- export all testdata files via filegroup

## Testing
- `bazel test //gazelle:gazelle_tests --test_output=errors`
- `bazel test //... --test_output=errors`


------
https://chatgpt.com/codex/tasks/task_b_683f6c3ecb28832baf5cefd5a91417df