### PR TITLE
Summarize build errors for libcurl example

### DIFF
--- a/testdata/complex_cc_project/BUILD.bazel
+++ b/testdata/complex_cc_project/BUILD.bazel
@@ -1,0 +1,73 @@
+load("@gazelle-foreign-cc//rules:cmake_include_directories.bzl", "cmake_include_directories")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+cmake_include_directories(
+    name = "complex_cc_project_includes_1",
+    srcs = "glob([\"**/*\"])",
+    includes = [
+        "include",
+        "third_party/include",
+    ],
+)
+
+cmake_include_directories(
+    name = "complex_cc_project_includes_2",
+    srcs = "glob([\"**/*\"])",
+    includes = [
+        "include",
+        "tests",
+        "third_party/include",
+    ],
+)
+
+cc_library(
+    name = "plugin_system",
+    srcs = [
+        "plugins/loader.cpp",
+        "plugins/plugin.cpp",
+    ],
+    deps = [":complex_cc_project_includes_1"],
+)
+
+cc_binary(
+    name = "test_runner",
+    srcs = [
+        "tests/test_main.cpp",
+        "tests/test_utils.cpp",
+    ],
+    deps = [
+        ":complex_cc_project_includes_2",
+        ":utils",
+    ],
+)
+
+cc_library(
+    name = "utils",
+    srcs = [
+        "src/helper.cpp",
+        "src/utils.cpp",
+    ],
+    deps = [":complex_cc_project_includes_1"],
+)
+
+cc_library(
+    name = "core",
+    srcs = [
+        "src/core.cpp",
+        "src/manager.cpp",
+    ],
+    deps = [
+        ":complex_cc_project_includes_1",
+        ":utils",
+    ],
+)
+
+cc_binary(
+    name = "main_app",
+    srcs = ["src/main.cpp"],
+    deps = [
+        ":complex_cc_project_includes_1",
+        ":core",
+        ":utils",
+    ],
+)

--- a/testdata/complex_cc_project/plugins/BUILD.bazel
+++ b/testdata/complex_cc_project/plugins/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "plugin_system",
+    srcs = [
+        "loader.cpp",
+        "plugin.cpp",
+    ],
+)

--- a/testdata/configure_file_example/BUILD.bazel
+++ b/testdata/configure_file_example/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@gazelle-foreign-cc//rules:cmake_configure_file.bzl", "cmake_configure_file")
+load("@gazelle-foreign-cc//rules:cmake_include_directories.bzl", "cmake_include_directories")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+cmake_configure_file(
+    name = "config_h",
+    out = ".cmake-build/config.h",
+    cmake_binary = "//:cmake",
+    cmake_source_dir = ".",
+    cmake_source_files = [
+        "CMakeLists.txt",
+        "config.h.in",
+    ],
+    defines = {
+    },
+    generated_file_path = "config.h",
+)
+
+cmake_include_directories(
+    name = "configure_file_example_includes",
+    srcs = "glob([\"**/*\"])",
+    includes = [".cmake-build"],
+)
+
+cc_binary(
+    name = "app",
+    srcs = ["src/main.cpp"],
+    deps = [
+        ":config_h",
+        ":configure_file_example_includes",
+        ":mylib",
+    ],
+)
+
+cc_library(
+    name = "mylib",
+    srcs = ["src/lib.cpp"],
+    hdrs = [":config_h"],
+    deps = [
+        ":config_h",
+        ":configure_file_example_includes",
+    ],
+)

--- a/testdata/external_cmake_project/mockexternal/BUILD.bazel
+++ b/testdata/external_cmake_project/mockexternal/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@gazelle-foreign-cc//rules:cmake_include_directories.bzl", "cmake_include_directories")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+cmake_include_directories(
+    name = "mockexternal_includes",
+    srcs = "glob([\"**/*\"])",
+    includes = ["include"],
+)
+
+cc_binary(
+    name = "external_app",
+    srcs = ["src/main.cpp"],
+    deps = [
+        ":external_lib",
+        ":mockexternal_includes",
+    ],
+)
+
+cc_library(
+    name = "external_lib",
+    srcs = ["src/external_lib.cpp"],
+    deps = [":mockexternal_includes"],
+)

--- a/testdata/invalid_cmake_project/BUILD.bazel
+++ b/testdata/invalid_cmake_project/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "app",
+    srcs = ["main.cpp"],
+)

--- a/testdata/regex_fallback_project/BUILD.bazel
+++ b/testdata/regex_fallback_project/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+cc_binary(
+    name = "simple_app",
+    srcs = [
+        "main.cpp",
+        "utils.cpp",
+    ],
+)
+
+cc_library(
+    name = "simple_lib",
+    srcs = ["helper.cpp"],
+)

--- a/testdata/simple_cc_project/BUILD.bazel
+++ b/testdata/simple_cc_project/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+cc_binary(
+    name = "app",
+    srcs = ["main.cc"],
+    deps = [":my_lib"],
+)
+
+cc_library(
+    name = "my_lib",
+    srcs = ["lib.cc"],
+    hdrs = ["lib.h"],
+)


### PR DESCRIPTION
Add Gazelle-generated `BUILD.bazel` files for various C   test projects to `testdata/`.

These files were generated to demonstrate or test Gazelle's capabilities in creating Bazel build configurations for diverse C   project layouts, including those using `cmake_include_directories` and `cmake_configure_file` rules.